### PR TITLE
CAA-79: Redirect /api to docs at musicbrainz.org.

### DIFF
--- a/coverart_redirect/request.py
+++ b/coverart_redirect/request.py
@@ -244,6 +244,10 @@ class CoverArtRedirect(object):
         '''Serve up a permissive robots.txt'''
         return Response(response="User-agent: *\nAllow: /", mimetype='text/plain')
 
+    def handle_api(self):
+        '''Redirect to API docs at musicbrainz.org'''
+        return request.redirect (code=301, location='https://musicbrainz.org/doc/Cover_Art_Archive/API')
+
     def handle_dir(self, request, mbid):
         '''When the user requests no file, redirect to the root of the bucket to give the user an
            index of what is in the bucket'''
@@ -346,6 +350,8 @@ class CoverArtRedirect(object):
             return self.handle_index()
         if entity == 'robots.txt':
             return self.handle_robots()
+        if entity == 'api':
+            return self.handle_api()
 
         self.validate_entity(entity)
 


### PR DESCRIPTION
Not tested, since I couldn't get it running locally (yet).

Reasoning: It's much easier to remember caa.o/api to quickly look up the docs, than it is to remember the mb.o/docs/... URL and faster than going to caa.o first and then clicking through to the docs link.