### PR TITLE
Add support for ratelimit-server

### DIFF
--- a/coverart_redirect/config.py
+++ b/coverart_redirect/config.py
@@ -57,6 +57,14 @@ class DatabaseConfig(object):
         if parser.has_option(section, 'password'):
             self.password = parser.get(section, 'password')
 
+class RateLimitServerConfig(object):
+    def __init__(self):
+        self.host = None
+        self.port = None
+
+    def read(self, parser, section):
+        self.host = parser.get(section, 'host')
+        self.port = parser.get(section, 'port')
 
 class Config(object):
 
@@ -73,5 +81,5 @@ class Config(object):
         self.listen.read(parser, 'listen')
         self.s3 = S3Config()
         self.s3.read(parser, 's3')
-
-
+        self.rate_limit_server = RateLimitServerConfig()
+        self.rate_limit_server.read(parser, 'rate_limit_server')

--- a/coverart_redirect/rate_limit.py
+++ b/coverart_redirect/rate_limit.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python2
+
+# Copyright (C) 2015 MetaBrainz Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import sys
+import re
+import socket
+import select
+from werkzeug.wrappers import Response
+
+HTTP_SERVICE_UNAVAILABLE = 503
+
+class RateLimiter(object):
+
+    def __init__(self, config):
+        self.config = config
+        self.socket = None
+        self.id = 0
+
+    def get_socket(self):
+        if self.socket:
+            return self.socket
+
+        self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.getprotobyname('udp'))
+        config = self.config.rate_limit_server
+
+        try:
+            self.socket.connect((config.host, int(config.port)))
+        except socket.error as e:
+            print >> sys.stderr, ('socket.connect error: %s' % e)
+            return None
+
+        return self.socket
+
+    def reset_socket(self):
+        if self.socket:
+            self.socket.close()
+            self.socket = None
+
+    def check_rate_limit(self, key):
+        s = self.get_socket()
+
+        if not s:
+            return None
+
+        self.id += 1
+        self.id &= 0xFFFF
+
+        bytes_sent = s.send('%s over_limit %s' % (self.id, key))
+        if bytes_sent == 0:
+            return None
+
+        ready = select.select([s], [], [], 0.1)
+        if s not in ready[0]:
+            return None
+
+        # Note: recv is blocking.
+        data = s.recv(1000)
+
+        if not re.search(r'\A(%s) /' % (self.id,), data):
+            self.reset_socket()
+            return None
+
+        match = re.match(r'^ok ([YN]) ([\d.]+) ([\d.]+) (\d+)$', data)
+        if match:
+            is_over_limit = match.group(1) == 'Y'
+            if is_over_limit:
+                return Response(
+                    status=HTTP_SERVICE_UNAVAILABLE,
+                    headers=[('X-Rate-Limited', '%.1f %.1f %d' % match.group(2, 3, 4))]
+                )

--- a/coverart_redirect/server.py
+++ b/coverart_redirect/server.py
@@ -64,7 +64,7 @@ class Server(object):
 
     @Request.application
     def __call__(self, request):
-        rate_limiter_response = self.rate_limiter.check_rate_limit('frontend ip=%s' % request.remote_addr);
+        rate_limiter_response = self.rate_limiter.check_rate_limit('caa ip=%s' % request.remote_addr);
         if rate_limiter_response:
             return rate_limiter_response
 


### PR DESCRIPTION
Allows the server to communicate with ratelimit-server. Ported from musicbrainz-server's code & tested against a local instance of ratelimit-server (but since this stuff is fairly new to me, a thorough sanity check would be nice).