### PR TITLE
CAA-111: Fix filename split

### DIFF
--- a/coverart_redirect/request.py
+++ b/coverart_redirect/request.py
@@ -55,7 +55,7 @@ class CoverArtRedirect(object):
         if '-' not in filename:
             return ""
 
-        id, size = filename.split('-')
+        id, size = filename.rsplit('-', 1)
 
         if size.startswith('250'):
             return "-250"

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -196,6 +196,7 @@ class All(unittest.TestCase):
             '/release/353710ec-1509-4df9-8ce2-9bd5011e3b80/foo',
             '/release/353710ec-1509-4df9-8ce2-9bd5011e3b80/front-100',
             '/release/353710ec-1509-4df9-8ce2-9bd5011e3b80/-250',
+            '/release/353710ec-1509-4df9-8ce2-9bd5011e3b80/front-back-500',
         ]:
             response = self.server.open(path=path,
                                         method='OPTIONS')


### PR DESCRIPTION
# Fix [CAA-111](https://tickets.metabrainz.org/browse/CAA-111): Caught exception on filename split

Handle filenames that contain extraneous dash ahead of the separator between id and size.

Trigger a `BAD REQUEST` exception for invalid filenames that contain multiple dashes.